### PR TITLE
Fix for issue #88 re slider bounds on scaled datacubes. Fixed same is…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Code/includes.pri
 build-*
 **/.DS_Store
 Code/build/
+CMakeLists.txt.user
+

--- a/Code/src/pqwindowcube.cpp
+++ b/Code/src/pqwindowcube.cpp
@@ -313,8 +313,7 @@ void pqWindowCube::showLegendScaleActors()
 void pqWindowCube::showSlice()
 {
     // Slice in Cube Renderer
-   
-    
+
     cubeSliceProxy = builder->createDataRepresentation(this->CubeSource->getOutputPort(0), viewCube)
                              ->getProxy();
     vtkSMPropertyHelper(cubeSliceProxy, "Representation").Set("Slice");
@@ -441,7 +440,7 @@ void pqWindowCube::removeContours()
 
 void pqWindowCube::on_sliceSlider_valueChanged()
 {
-    //Check what caused the value to change, and don't update while sliding.
+    // Check what caused the value to change, and don't update while sliding.
     if (!loadChange)
         return;
 
@@ -458,12 +457,12 @@ void pqWindowCube::on_sliceSlider_valueChanged()
 
 void pqWindowCube::on_sliceSlider_actionTriggered(int action)
 {
-    //Set the slider to only update the image when released or changed by keyboard/mouse
+    // Set the slider to only update the image when released or changed by keyboard/mouse
     switch (action) {
-    case 0:
+    case QSlider::SliderNoAction:
         loadChange = false;
         break;
-    case 7:
+    case QSlider::SliderMove:
         loadChange = false;
         break;
     default:
@@ -472,7 +471,8 @@ void pqWindowCube::on_sliceSlider_actionTriggered(int action)
     }
 }
 
-void pqWindowCube::on_sliceSlider_sliderReleased(){
+void pqWindowCube::on_sliceSlider_sliderReleased()
+{
     int value = ui->sliceSlider->value();
 
     // Match slider and spinbox values
@@ -484,13 +484,14 @@ void pqWindowCube::on_sliceSlider_sliderReleased(){
     loadChange = false;
 }
 
-void pqWindowCube::on_sliceSpinBox_valueChanged(int arg1){
+void pqWindowCube::on_sliceSpinBox_valueChanged(int arg1)
+{
     // Match slider and spinbox values
     if (ui->sliceSlider->value() != arg1) {
         ui->sliceSlider->setValue(arg1);
         ui->sliceSlider->update();
     }
-    
+
     setSliceDatacube(arg1);
 }
 
@@ -531,7 +532,7 @@ void pqWindowCube::setSliceDatacube(int value)
     CubeSource->getProxy()->UpdatePropertyInformation();
     int sF;
     vtkSMPropertyHelper(CubeSource->getProxy(), "ScaleFactorInfo").Get(&sF);
-    int slicePos = std::round(((float) currentSlice) / sF);
+    int slicePos = std::round(((float)currentSlice) / sF);
     vtkSMPropertyHelper(cubeSliceProxy, "Slice").Set(slicePos);
     vtkSMPropertyHelper(cubeSliceProxy, "SliceMode").Set(VTK_XY_PLANE);
     cubeSliceProxy->UpdateVTKObjects();
@@ -739,4 +740,3 @@ void pqWindowCube::setVolumeRenderingOpacity(double opacity)
     contourProxy->UpdateVTKObjects();
     viewCube->render();
 }
-

--- a/Code/src/pqwindowcube.cpp
+++ b/Code/src/pqwindowcube.cpp
@@ -450,6 +450,37 @@ void pqWindowCube::on_sliceSlider_sliderReleased()
     setSliceDatacube(value);
 }
 
+void pqWindowCube::on_sliceSlider_valueChanged()
+{
+    if (!loadChange)
+        return;
+
+    int value = ui->sliceSlider->value();
+
+    // Match slider and spinbox values
+    if (ui->sliceSpinBox->value() != value) {
+        ui->sliceSpinBox->setValue(value);
+    }
+
+    setSliceDatacube(value);
+    loadChange = false;
+}
+
+void pqWindowCube::on_sliceSlider_actionTriggered(int action)
+{
+    switch (action) {
+    case 0:
+        loadChange = false;
+        break;
+    case 7:
+        loadChange = false;
+        break;
+    default:
+        loadChange = true;
+        break;
+    }
+}
+
 void pqWindowCube::on_sliceSpinBox_valueChanged(int arg1){
     // Match slider and spinbox values
     if (ui->sliceSlider->value() != arg1) {
@@ -494,7 +525,8 @@ void pqWindowCube::setSliceDatacube(int value)
     sliceProxy->UpdateVTKObjects();
     SliceSource->updatePipeline();
 
-    vtkSMPropertyHelper(cubeSliceProxy, "Slice").Set(currentSlice);
+    int slicePos = std::round(((float) currentSlice) / cubeSubset.ScaleFactor);
+    vtkSMPropertyHelper(cubeSliceProxy, "Slice").Set(slicePos);
     vtkSMPropertyHelper(cubeSliceProxy, "SliceMode").Set(VTK_XY_PLANE);
     cubeSliceProxy->UpdateVTKObjects();
 
@@ -701,3 +733,4 @@ void pqWindowCube::setVolumeRenderingOpacity(double opacity)
     contourProxy->UpdateVTKObjects();
     viewCube->render();
 }
+

--- a/Code/src/pqwindowcube.cpp
+++ b/Code/src/pqwindowcube.cpp
@@ -528,8 +528,9 @@ void pqWindowCube::setSliceDatacube(int value)
     sliceProxy->UpdateVTKObjects();
     SliceSource->updatePipeline();
 
+    CubeSource->getProxy()->UpdatePropertyInformation();
     int sF;
-    vtkSMPropertyHelper(CubeSource->getProxy(), "ScaleFactor").Get(&sF);
+    vtkSMPropertyHelper(CubeSource->getProxy(), "ScaleFactorInfo").Get(&sF);
     int slicePos = std::round(((float) currentSlice) / sF);
     vtkSMPropertyHelper(cubeSliceProxy, "Slice").Set(slicePos);
     vtkSMPropertyHelper(cubeSliceProxy, "SliceMode").Set(VTK_XY_PLANE);

--- a/Code/src/pqwindowcube.h
+++ b/Code/src/pqwindowcube.h
@@ -26,8 +26,7 @@ class pqWindowCube : public QMainWindow
     using FitsHeaderMap = QMap<QString, QString>;
 
 public:
-    explicit pqWindowCube(const QString &filepath,
-                          const CubeSubset &cubeSubset = CubeSubset());
+    explicit pqWindowCube(const QString &filepath, const CubeSubset &cubeSubset = CubeSubset());
     ~pqWindowCube() override;
 
 private slots:
@@ -58,7 +57,6 @@ private slots:
     void on_action100_triggered();
 
     void generateVolumeRendering();
-
 
 private:
     Ui::pqWindowCube *ui;

--- a/Code/src/pqwindowcube.h
+++ b/Code/src/pqwindowcube.h
@@ -31,7 +31,9 @@ public:
     ~pqWindowCube() override;
 
 private slots:
+    void on_sliceSlider_actionTriggered(int action);
     void on_sliceSlider_sliderReleased();
+    void on_sliceSlider_valueChanged();
     void on_sliceSpinBox_editingFinished();
     void on_sliceSpinBox_valueChanged(int arg1);
     void on_actionFront_triggered();
@@ -56,6 +58,7 @@ private slots:
     void on_action100_triggered();
 
     void generateVolumeRendering();
+
 
 private:
     Ui::pqWindowCube *ui;
@@ -112,6 +115,8 @@ private:
 
     void showContours();
     void removeContours();
+
+    bool loadChange = false;
 };
 
 #endif // PQWINDOWCUBE_H


### PR DESCRIPTION
…sue on slice position spinbox. Also fixed issue where slider position if changed by method other than click and drag didn't update slice position. Can revert that change if it was intended behaviour.