### PR TITLE
Throw error message when loading image that doesn't overlap existing images.

### DIFF
--- a/Code/src/pqwindowimage.cpp
+++ b/Code/src/pqwindowimage.cpp
@@ -121,6 +121,13 @@ void pqWindowImage::showStatusBarMessage(const std::string &msg)
     ui->statusBar->showMessage(QString::fromStdString(msg));
 }
 
+/**
+ * @brief pqWindowImage::throwError
+ * A standardised error message that can be thrown from anywhere in the class.
+ * @param text The error message
+ * @param info More detailed information, such as the next step to take or
+ *             steps that could resolve the issue.
+ */
 void pqWindowImage::throwError(const QString &text, const QString &info)
 {
     QMessageBox e;

--- a/Code/src/pqwindowimage.h
+++ b/Code/src/pqwindowimage.h
@@ -88,6 +88,8 @@ private:
     void changeColorMap(const QString &name);
     void showStatusBarMessage(const std::string &msg);
 
+    void throwError(const QString& text, const QString& info = "");
+
     void updateUI();
 
     void setImageListCheckbox(int row, Qt::CheckState checked);

--- a/Code/src/vlvastackimage.cpp
+++ b/Code/src/vlvastackimage.cpp
@@ -69,6 +69,7 @@ int vlvaStackImage::init(QString f, CubeSubset subset)
         setOpacity(1);
         setActive(true);
         type = 0;
+        pixCount = std::make_pair(fitsHeader.value("NAXIS1").toInt(), fitsHeader.value("NAXIS2").toInt());
     }
     catch (std::exception& e)
     {
@@ -101,6 +102,18 @@ const QString vlvaStackImage::getFitsFileName() const
 bool vlvaStackImage::operator<(const vlvaStackImage &other) const
 {
     return this->getIndex() < other.getIndex();
+}
+
+bool vlvaStackImage::operator==(const vlvaStackImage &other) const
+{
+    if (this->getFitsFileName() != other.getFitsFileName())
+        return false;
+    return true;
+}
+
+const std::pair<int, int> vlvaStackImage::getPixCount() const
+{
+    return pixCount;
 }
 
 int vlvaStackImage::setSubsetProperties(CubeSubset& subset)
@@ -419,7 +432,7 @@ int vlvaStackImage::setOpacity(float value, bool updateVal)
     }
 }
 
-int vlvaStackImage::setPosition(double x, double y)
+int vlvaStackImage::setXYPosition(double x, double y)
 {
     if (initialised)
     {
@@ -432,6 +445,11 @@ int vlvaStackImage::setPosition(double x, double y)
         std::cerr << "StackImage not initialised, returning default value." << std::endl;
         return 0;
     }
+}
+
+const std::pair<double, double> vlvaStackImage::getXYPosition() const
+{
+    return this->xyPosition;
 }
 
 int vlvaStackImage::setZPosition()
@@ -472,6 +490,7 @@ int vlvaStackImage::setScale(double x, double y, double z)
             vtkSMPropertyHelper(scaleProperty).Set(val, 3);
             imageProxy->UpdateVTKObjects();
             delete[] val;
+            this->scale = std::make_tuple(x, y, z);
             return 1;
         }
         std::cerr << "Error with scale proxy: not found correctly." << std::endl;

--- a/Code/src/vlvastackimage.h
+++ b/Code/src/vlvastackimage.h
@@ -1,6 +1,7 @@
 #ifndef VLVASTACKIMAGE_H
 #define VLVASTACKIMAGE_H
 
+#include "src/astroutils.h"
 #include "subsetselectordialog.h"
 
 #include "pqObjectBuilder.h"
@@ -35,9 +36,12 @@ public:
         const double getOpacity() const;
         int setOpacity(float value, bool updateVal = true);
 
-        int setPosition(double x, double y);
+        int setXYPosition(double x, double y);
+        const std::pair<double, double> getXYPosition() const;
+        const std::pair<int, int> getPixCount() const;
         int setZPosition();
         int setScale(double x, double y, double z = 1);
+        const std::tuple<double, double, double> getScale() const;
         int setOrientation(double phi, double theta, double psi);
         const std::tuple<double, double, double> getOrientation() const;
         void setIndex(const size_t val);
@@ -51,15 +55,19 @@ public:
         int getType() const { return type; };
 
         bool operator<(const vlvaStackImage& other) const;
+        bool operator==(const vlvaStackImage& other) const;
+
     private:
         int index;
         bool logScale, active;
         bool initialised;
         QString colourMap;
         double opacity;
-        std::tuple<double, double, double> angle;
 
+        std::tuple<double, double, double> angle;
         std::pair<double, double> xyPosition;
+        std::pair<int, int> pixCount;
+        std::tuple<double, double, double> scale;
 
         vtkSMSessionProxyManager* serverProxyManager;
         pqObjectBuilder* builder;
@@ -93,5 +101,15 @@ public:
         void readInfoFromSource();
         void readHeaderFromSource();
 };
+
+static bool overlaps(const std::vector<vlvaStackImage*>& imgs, const vlvaStackImage* evalImg){
+    for (auto i : imgs){
+        if (i == evalImg)
+            continue;
+        if (AstroUtils().CheckOverlap(i->getFitsHeaderPath(), evalImg->getFitsHeaderPath()))
+            return 1;
+    }
+    return 0;
+}
 
 #endif // VLVASTACKIMAGE_H


### PR DESCRIPTION
  * Resolve #116.
  * Create framework for error messages to be thrown.
  * Add error messages to a few other places.